### PR TITLE
Fix issue #88

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -3,6 +3,8 @@ set -e
 set -E
 set -T
 
+export BATS_TEST_SKIPPED=
+
 BATS_COUNT_ONLY=""
 if [ "$1" = "-c" ]; then
   BATS_COUNT_ONLY=1


### PR DESCRIPTION
Fix for: set -o nounset make exit trap fail. · Issue #88 · sstephenson/bats
https://github.com/sstephenson/bats/issues/88